### PR TITLE
Relax version constraint on "base" package

### DIFF
--- a/path-tree.cabal
+++ b/path-tree.cabal
@@ -22,7 +22,7 @@ extra-source-files:
 
 library
   build-depends:
-    , base >=4.13.0.0 && <=4.18.0.0
+    , base >=4.13.0.0 && <5
     , containers
     , relude
 


### PR DESCRIPTION
This lets it build with GHC 9.6 and GHC 9.8.
